### PR TITLE
ci: fix failing tests

### DIFF
--- a/test/dummy/bin/webpacker
+++ b/test/dummy/bin/webpacker
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+
+require "pathname"
+require "bundler/setup"
+require "webpacker"
+require "webpacker/webpack_runner"
+
+ENV["RAILS_ENV"] ||= "development"
+ENV["NODE_ENV"]  ||= ENV["RAILS_ENV"]
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../../Gemfile", Pathname.new(__FILE__).realpath)
+
+APP_ROOT = File.expand_path("..", __dir__)
+Dir.chdir(APP_ROOT) do
+  Webpacker::WebpackRunner.run(ARGV)
+end


### PR DESCRIPTION
CI tests complained because bin/webpacker wasn't found
Here's link to CI https://app.circleci.com/pipelines/github/appfolio/ae_test_coverage
